### PR TITLE
Portfolio website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,115 @@
-# portfolio
-portfolio website
+# Portfolio Website Roadmap
+
+These steps walk through building a personal portfolio inspired by [andrewschmidt.net](https://www.andrewschmidt.net/). Adapt the content, visuals, and tooling to fit your own story.
+
+## 1. Discover and Plan
+1. **Audit the reference site**
+   * Note the overall sections: hero intro, highlighted projects, testimonials, writing, and contact.
+   * Record layout patterns (two-column hero, project cards, call-to-action buttons) and interaction details (hover effects, smooth scrolling, animated transitions).
+2. **Define your content**
+   * Gather your professional summary, featured projects, testimonials, resume link, and social profiles.
+   * Draft copy for each section, including project descriptions with technologies and outcomes.
+3. **Sketch your information architecture**
+   * Create a sitemap (e.g., Home, Projects, About, Contact, Blog).
+   * Wireframe desktop and mobile layouts inspired by the reference while keeping your branding distinct.
+
+## 2. Choose the Tech Stack
+1. **Framework options**
+   * Static HTML/CSS with small sprinkles of vanilla JS.
+   * Static-site generators (Astro, Eleventy) for templating + Markdown content.
+   * React-based frameworks (Next.js) if you expect dynamic content or CMS integration.
+2. **Styling strategy**
+   * Utility-first CSS (Tailwind) for rapid layout building.
+   * Component libraries (Chakra UI) for pre-built sections.
+   * Custom SCSS/CSS Modules for full control.
+3. **Tooling**
+   * Initialize with `npm create` (or `pnpm`, `yarn`) for the chosen framework.
+   * Add TypeScript if you want type safety.
+   * Configure Prettier/ESLint for consistent formatting.
+
+## 3. Set Up the Project
+1. **Initialize the repository**
+   * Run `git init` (already done here) and configure `.gitignore` based on the stack.
+2. **Scaffold pages**
+   * Create layout components: navigation, footer, section wrapper.
+   * Build reusable components for project cards, testimonial blocks, article previews.
+3. **Add global styling**
+   * Implement a design system: colors, typography, spacing, button styles.
+   * Configure responsive breakpoints that match your wireframes.
+
+## 4. Implement Core Sections
+1. **Hero section**
+   * Two-column layout with portrait/photo on one side and headline, intro copy, and primary call-to-action on the other.
+   * Include quick links (email, social icons) and subtle entrance animation.
+2. **Projects showcase**
+   * Use cards with screenshots, tech stack tags, and outcome blurbs.
+   * Provide prominent buttons for live demo and case study.
+3. **Testimonials / Social proof**
+   * Add quotes from colleagues or clients with names, roles, and avatars.
+4. **Writing or blog teasers**
+   * Display latest articles with dates and short excerpts.
+5. **Contact / Call to action**
+   * Provide contact form or mailto link, plus secondary CTA (download resume).
+
+## 5. Enhance UX and Visual Polish
+1. **Animation & interaction**
+   * Apply scroll-based reveal animations (Framer Motion, GSAP, or CSS transitions).
+   * Add hover states on buttons/cards and smooth scroll for navigation links.
+2. **Performance optimization**
+   * Compress images, leverage responsive `<img>`/`<picture>` tags.
+   * Use lazy loading for below-the-fold sections.
+3. **Accessibility**
+   * Ensure semantic HTML structure, focus states, and sufficient color contrast.
+   * Test with keyboard navigation and screen readers (VoiceOver/NVDA).
+
+## 6. Add Supporting Pages and Content
+1. **About / Resume**
+   * Provide detailed biography, skills matrix, and timeline of experience.
+2. **Project case studies**
+   * Create dedicated pages for flagship projects with problem/solution breakdowns, metrics, and visuals.
+3. **Blog / Writing**
+   * Connect to a CMS (Contentful, Sanity) or use Markdown-based workflow.
+
+## 7. Test Thoroughly
+1. **Responsive testing**
+   * Verify layouts on mobile, tablet, and large desktop viewports.
+2. **Cross-browser checks**
+   * Test in Chrome, Safari, Firefox, and Edge.
+3. **Performance audits**
+   * Run Lighthouse for performance, accessibility, best practices, and SEO scores.
+4. **Content review**
+   * Proofread all copy; ensure external links open correctly and include `rel="noopener"`.
+
+## 8. Deploy and Maintain
+1. **Deployment options**
+   * Vercel (great for Next.js), Netlify (static/SSG), GitHub Pages (static sites), Cloudflare Pages.
+2. **Continuous integration**
+   * Set up automated builds/tests on push via GitHub Actions or provider defaults.
+3. **Custom domain**
+   * Purchase a domain, configure DNS (A/AAAA/CNAME records) to your hosting platform.
+4. **Analytics & monitoring**
+   * Add Google Analytics, Plausible, or Splitbee for traffic insights.
+   * Configure uptime monitoring (e.g., UptimeRobot).
+5. **Iterate**
+   * Schedule regular updates for new projects, articles, and design improvements.
+
+## 9. Resources to Explore Next
+* Design inspiration: [Dribbble](https://dribbble.com/), [Behance](https://www.behance.net/)
+* CSS animation libraries: [Framer Motion](https://www.framer.com/motion/), [GSAP](https://greensock.com/gsap/)
+* Accessibility checklists: [A11Y Project](https://www.a11yproject.com/checklist/)
+* Web performance: [web.dev](https://web.dev/)
+
+Use this checklist as a living document—update it as you refine your goals and tooling.
+
+## Running the Current Static Prototype
+
+The repository currently contains a static prototype (`index.html`, `styles.css`, and `scripts/main.js`). You can preview it in two ways:
+
+1. **Open the file directly**
+   * Double-click `index.html` in your file manager, or run `open index.html` (macOS) / `xdg-open index.html` (Linux) / `start index.html` (Windows) to launch it in your default browser.
+
+2. **Serve it over a local HTTP server** (recommended for testing fetch requests, relative paths, etc.)
+   * From the project root, run one of the following commands and visit the indicated URL:
+     * Python 3: `python -m http.server 8000`
+     * Node.js: `npx serve .`
+   * Open <http://localhost:8000> (or the port shown in the terminal) in your browser.

--- a/index.html
+++ b/index.html
@@ -26,7 +26,6 @@
           <ul id="primary-navigation" data-open="false">
             <li><a href="#work">Work</a></li>
             <li><a href="#about">About</a></li>
-            <li><a href="#writing">Writing</a></li>
             <li><a href="#contact">Contact</a></li>
             <li><a class="btn btn--ghost" href="#resume">Resume</a></li>
           </ul>
@@ -69,62 +68,87 @@
             <p class="eyebrow">Selected Work</p>
             <h2>Case studies and collaborations</h2>
           </div>
-          <div class="grid grid--projects">
-            <article class="project-card">
-              <div class="project-card__media">Hero Image Placeholder</div>
-              <div class="project-card__body">
-                <h3>Project Title One</h3>
-                <p>
-                  Brief description of the project outcome. Summarize impact, highlight metrics, and mention the team or role you
-                  played.
-                </p>
-                <ul class="tag-list">
-                  <li>UX Strategy</li>
-                  <li>Design Systems</li>
-                  <li>Research</li>
-                </ul>
-                <div class="project-card__actions">
-                  <a class="btn" href="#">Read case study</a>
-                  <a class="btn btn--ghost" href="#">Live product</a>
+          <div class="work-group">
+            <h3 class="work-group__title">UX Writing</h3>
+            <div class="grid grid--projects">
+              <article class="project-card">
+                <div class="project-card__media">Hero Image Placeholder</div>
+                <div class="project-card__body">
+                  <h4>Voice &amp; Tone System</h4>
+                  <p>
+                    Outline how you established a unified messaging playbook that strengthened product narratives across core
+                    surfaces.
+                  </p>
+                  <ul class="tag-list">
+                    <li>Voice &amp; Tone</li>
+                    <li>Content Strategy</li>
+                    <li>Cross-functional Alignment</li>
+                  </ul>
+                  <div class="project-card__actions">
+                    <a class="btn" href="#">Read case study</a>
+                  </div>
                 </div>
-              </div>
-            </article>
-            <article class="project-card">
-              <div class="project-card__media">Hero Image Placeholder</div>
-              <div class="project-card__body">
-                <h3>Project Title Two</h3>
-                <p>
-                  Summarize the challenge, your contributions, and measurable results. Keep the copy concise and outcomes-focused.
-                </p>
-                <ul class="tag-list">
-                  <li>Product Strategy</li>
-                  <li>Prototyping</li>
-                  <li>Leadership</li>
-                </ul>
-                <div class="project-card__actions">
-                  <a class="btn" href="#">Read case study</a>
-                  <a class="btn btn--ghost" href="#">Live product</a>
+              </article>
+              <article class="project-card">
+                <div class="project-card__media">Hero Image Placeholder</div>
+                <div class="project-card__body">
+                  <h4>Lifecycle Messaging Refresh</h4>
+                  <p>
+                    Describe the iterative experiments that transformed onboarding and retention flows with data-backed copy improv
+ements.
+                  </p>
+                  <ul class="tag-list">
+                    <li>Email Strategy</li>
+                    <li>Experimentation</li>
+                    <li>UX Research</li>
+                  </ul>
+                  <div class="project-card__actions">
+                    <a class="btn" href="#">Read case study</a>
+                  </div>
                 </div>
-              </div>
-            </article>
-            <article class="project-card">
-              <div class="project-card__media">Hero Image Placeholder</div>
-              <div class="project-card__body">
-                <h3>Project Title Three</h3>
-                <p>
-                  Use this space to feature a recent collaboration or personal project. Focus on process, learnings, and value.
-                </p>
-                <ul class="tag-list">
-                  <li>UX Research</li>
-                  <li>UI Design</li>
-                  <li>Accessibility</li>
-                </ul>
-                <div class="project-card__actions">
-                  <a class="btn" href="#">Read case study</a>
-                  <a class="btn btn--ghost" href="#">Live product</a>
+              </article>
+            </div>
+          </div>
+          <div class="work-group">
+            <h3 class="work-group__title">Localization</h3>
+            <div class="grid grid--projects">
+              <article class="project-card">
+                <div class="project-card__media">Hero Image Placeholder</div>
+                <div class="project-card__body">
+                  <h4>Global Product Launch</h4>
+                  <p>
+                    Share how you prepared multi-market product copy, coordinating translation partners and regional stakeholder
+s.
+                  </p>
+                  <ul class="tag-list">
+                    <li>Localization Ops</li>
+                    <li>Vendor Management</li>
+                    <li>Quality Assurance</li>
+                  </ul>
+                  <div class="project-card__actions">
+                    <a class="btn" href="#">Read case study</a>
+                  </div>
                 </div>
-              </div>
-            </article>
+              </article>
+              <article class="project-card">
+                <div class="project-card__media">Hero Image Placeholder</div>
+                <div class="project-card__body">
+                  <h4>Regional Voice Adaptation</h4>
+                  <p>
+                    Explain the systems you built to adapt core experiences for priority regions while preserving brand voice and
+ consistency.
+                  </p>
+                  <ul class="tag-list">
+                    <li>Market Research</li>
+                    <li>Content Ops</li>
+                    <li>Stakeholder Alignment</li>
+                  </ul>
+                  <div class="project-card__actions">
+                    <a class="btn" href="#">Read case study</a>
+                  </div>
+                </div>
+              </article>
+            </div>
           </div>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Portfolio – Your Name</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container">
+        <a class="logo" href="#top">Your Name</a>
+        <nav class="site-nav" aria-label="Primary">
+          <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">
+            <span class="visually-hidden">Menu</span>
+            <span class="nav-toggle__bar"></span>
+            <span class="nav-toggle__bar"></span>
+            <span class="nav-toggle__bar"></span>
+          </button>
+          <ul id="primary-navigation" data-open="false">
+            <li><a href="#work">Work</a></li>
+            <li><a href="#about">About</a></li>
+            <li><a href="#writing">Writing</a></li>
+            <li><a href="#contact">Contact</a></li>
+            <li><a class="btn btn--ghost" href="#resume">Resume</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main id="top">
+      <section class="hero">
+        <div class="container hero__layout">
+          <div class="hero__content">
+            <p class="eyebrow">Product Designer &amp; Engineer</p>
+            <h1>Crafting thoughtful experiences that balance business and user needs.</h1>
+            <p class="lead">
+              I'm <span class="placeholder">Your Name</span>, a <span class="placeholder">role</span> focused on building
+              accessible, resilient digital products. I help teams translate complex problems into intuitive solutions.
+            </p>
+            <div class="hero__actions">
+              <a class="btn" href="#work">View selected work</a>
+              <a class="btn btn--ghost" href="#contact">Let's collaborate</a>
+            </div>
+            <ul class="hero__links">
+              <li><a href="mailto:hello@example.com">hello@example.com</a></li>
+              <li><a href="#">LinkedIn</a></li>
+              <li><a href="#">Dribbble</a></li>
+              <li><a href="#">GitHub</a></li>
+            </ul>
+          </div>
+          <div class="hero__visual">
+            <div class="portrait" aria-hidden="true">
+              <span>Portrait Placeholder</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="work" class="section section--muted">
+        <div class="container">
+          <div class="section__header">
+            <p class="eyebrow">Selected Work</p>
+            <h2>Case studies and collaborations</h2>
+          </div>
+          <div class="grid grid--projects">
+            <article class="project-card">
+              <div class="project-card__media">Hero Image Placeholder</div>
+              <div class="project-card__body">
+                <h3>Project Title One</h3>
+                <p>
+                  Brief description of the project outcome. Summarize impact, highlight metrics, and mention the team or role you
+                  played.
+                </p>
+                <ul class="tag-list">
+                  <li>UX Strategy</li>
+                  <li>Design Systems</li>
+                  <li>Research</li>
+                </ul>
+                <div class="project-card__actions">
+                  <a class="btn" href="#">Read case study</a>
+                  <a class="btn btn--ghost" href="#">Live product</a>
+                </div>
+              </div>
+            </article>
+            <article class="project-card">
+              <div class="project-card__media">Hero Image Placeholder</div>
+              <div class="project-card__body">
+                <h3>Project Title Two</h3>
+                <p>
+                  Summarize the challenge, your contributions, and measurable results. Keep the copy concise and outcomes-focused.
+                </p>
+                <ul class="tag-list">
+                  <li>Product Strategy</li>
+                  <li>Prototyping</li>
+                  <li>Leadership</li>
+                </ul>
+                <div class="project-card__actions">
+                  <a class="btn" href="#">Read case study</a>
+                  <a class="btn btn--ghost" href="#">Live product</a>
+                </div>
+              </div>
+            </article>
+            <article class="project-card">
+              <div class="project-card__media">Hero Image Placeholder</div>
+              <div class="project-card__body">
+                <h3>Project Title Three</h3>
+                <p>
+                  Use this space to feature a recent collaboration or personal project. Focus on process, learnings, and value.
+                </p>
+                <ul class="tag-list">
+                  <li>UX Research</li>
+                  <li>UI Design</li>
+                  <li>Accessibility</li>
+                </ul>
+                <div class="project-card__actions">
+                  <a class="btn" href="#">Read case study</a>
+                  <a class="btn btn--ghost" href="#">Live product</a>
+                </div>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="about" class="section">
+        <div class="container">
+          <div class="section__header section__header--split">
+            <div>
+              <p class="eyebrow">About</p>
+              <h2>A human-centered leader grounded in craft</h2>
+            </div>
+            <div>
+              <p>
+                Share a short narrative about your background, approach, and values. Highlight the industries you have worked in,
+                the scale of products you've touched, and how you partner with teams.
+              </p>
+              <p>
+                Mention accolades, speaking engagements, or community work to add credibility. Link to your resume for deeper
+                context.
+              </p>
+            </div>
+          </div>
+          <div class="about__details">
+            <div>
+              <h3>Expertise</h3>
+              <ul class="bullet-list">
+                <li>Product discovery &amp; definition</li>
+                <li>Inclusive design systems</li>
+                <li>Design leadership &amp; mentorship</li>
+              </ul>
+            </div>
+            <div>
+              <h3>Selected partners</h3>
+              <ul class="bullet-list">
+                <li>Company One</li>
+                <li>Company Two</li>
+                <li>Company Three</li>
+              </ul>
+            </div>
+            <div>
+              <h3>Speaking &amp; writing</h3>
+              <ul class="bullet-list">
+                <li>Conference talk title</li>
+                <li>Workshop or webinar</li>
+                <li>Podcast appearance</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--muted">
+        <div class="container testimonials">
+          <div class="section__header">
+            <p class="eyebrow">Testimonials</p>
+            <h2>Words from collaborators</h2>
+          </div>
+          <div class="grid grid--testimonials">
+            <figure class="testimonial-card">
+              <blockquote>
+                “Add a compelling quote from a teammate or client that speaks to your collaboration style and impact.”
+              </blockquote>
+              <figcaption>
+                <span class="testimonial-card__name">Name Surname</span>
+                <span class="testimonial-card__role">Title · Company</span>
+              </figcaption>
+            </figure>
+            <figure class="testimonial-card">
+              <blockquote>
+                “Share another perspective that highlights your strengths, leadership, or craft excellence.”
+              </blockquote>
+              <figcaption>
+                <span class="testimonial-card__name">Name Surname</span>
+                <span class="testimonial-card__role">Title · Company</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section id="writing" class="section">
+        <div class="container">
+          <div class="section__header">
+            <p class="eyebrow">Writing</p>
+            <h2>Thinking out loud about product and design</h2>
+          </div>
+          <div class="grid grid--articles">
+            <article class="article-card">
+              <p class="article-card__meta">Month 00, 20XX</p>
+              <h3><a href="#">Article title placeholder that wraps to two lines</a></h3>
+              <p>
+                A short excerpt describing the article's takeaway or why it matters. Keep it punchy to encourage clicks.
+              </p>
+            </article>
+            <article class="article-card">
+              <p class="article-card__meta">Month 00, 20XX</p>
+              <h3><a href="#">Second article headline goes here</a></h3>
+              <p>
+                Use this to showcase thought leadership, share frameworks, or document learnings from recent projects.
+              </p>
+            </article>
+            <article class="article-card">
+              <p class="article-card__meta">Month 00, 20XX</p>
+              <h3><a href="#">Third article to feature</a></h3>
+              <p>
+                Link to blog posts, newsletters, or external publications. Provide just enough context to entice readers.
+              </p>
+            </article>
+          </div>
+          <div class="section__footer">
+            <a class="btn btn--ghost" href="#">View all writing</a>
+          </div>
+        </div>
+      </section>
+
+      <section id="resume" class="section section--muted">
+        <div class="container resume">
+          <div class="section__header section__header--split">
+            <div>
+              <p class="eyebrow">Resume</p>
+              <h2>Download the full story</h2>
+            </div>
+            <div>
+              <p>
+                Offer recruiters a straightforward way to review your background. Link to a PDF, Notion page, or resume site that
+                stays up to date.
+              </p>
+              <a class="btn" href="#">Download resume</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="section callout">
+        <div class="container callout__layout">
+          <div>
+            <p class="eyebrow">Contact</p>
+            <h2>Let's build the next thing together</h2>
+            <p>
+              Encourage visitors to reach out. Share your preferred channels and set expectations for response time or services.
+            </p>
+          </div>
+          <div>
+            <a class="btn btn--light" href="mailto:hello@example.com">hello@example.com</a>
+            <a class="btn btn--outline" href="#">Schedule a call</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer__layout">
+        <div>
+          <p class="logo">Your Name</p>
+          <p class="small-print">© <span id="current-year"></span> Your Name. All rights reserved.</p>
+        </div>
+        <ul class="footer__links">
+          <li><a href="#">LinkedIn</a></li>
+          <li><a href="#">Twitter</a></li>
+          <li><a href="#">Dribbble</a></li>
+          <li><a href="#">GitHub</a></li>
+        </ul>
+      </div>
+    </footer>
+
+    <script src="scripts/main.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -24,9 +24,8 @@
             <span class="nav-toggle__bar"></span>
           </button>
           <ul id="primary-navigation" data-open="false">
-            <li><a href="#work">Work</a></li>
+            <li><a href="#work">Projects</a></li>
             <li><a href="#about">About</a></li>
-            <li><a href="#contact">Contact</a></li>
             <li><a class="btn btn--ghost" href="#resume">Resume</a></li>
           </ul>
         </nav>
@@ -37,21 +36,18 @@
       <section class="hero">
         <div class="container hero__layout">
           <div class="hero__content">
-            <p class="eyebrow">Product Designer &amp; Engineer</p>
-            <h1>Crafting thoughtful experiences that balance business and user needs.</h1>
+            <p class="eyebrow">UX Writing &amp; Localization</p>
+            <h1>Designing clarity that travels well</h1>
             <p class="lead">
-              I'm <span class="placeholder">Your Name</span>, a <span class="placeholder">role</span> focused on building
-              accessible, resilient digital products. I help teams translate complex problems into intuitive solutions.
+              I'm <span class="placeholder">Yiqun Wu</span>, currently leading <span class="placeholder">UX Writing and Localization</span> for CapCut, the global video editor by Bytedance. I shape clear, culturally right product content, used by creators worldwide.
             </p>
             <div class="hero__actions">
               <a class="btn" href="#work">View selected work</a>
               <a class="btn btn--ghost" href="#contact">Let's collaborate</a>
             </div>
             <ul class="hero__links">
-              <li><a href="mailto:hello@example.com">hello@example.com</a></li>
-              <li><a href="#">LinkedIn</a></li>
-              <li><a href="#">Dribbble</a></li>
-              <li><a href="#">GitHub</a></li>
+              <li><a href="mailto:wuyiqun0902@outlook.com">wuyiqun0902@outlook.com</a></li>
+              <li><a href="https://www.linkedin.com/in/yiqun-wu/">LinkedIn</a></li>
             </ul>
           </div>
           <div class="hero__visual">
@@ -66,7 +62,6 @@
         <div class="container">
           <div class="section__header">
             <p class="eyebrow">Selected Work</p>
-            <h2>Case studies and collaborations</h2>
           </div>
           <div class="work-group">
             <h3 class="work-group__title">UX Writing</h3>
@@ -200,70 +195,6 @@ s.
         </div>
       </section>
 
-      <section class="section section--muted">
-        <div class="container testimonials">
-          <div class="section__header">
-            <p class="eyebrow">Testimonials</p>
-            <h2>Words from collaborators</h2>
-          </div>
-          <div class="grid grid--testimonials">
-            <figure class="testimonial-card">
-              <blockquote>
-                “Add a compelling quote from a teammate or client that speaks to your collaboration style and impact.”
-              </blockquote>
-              <figcaption>
-                <span class="testimonial-card__name">Name Surname</span>
-                <span class="testimonial-card__role">Title · Company</span>
-              </figcaption>
-            </figure>
-            <figure class="testimonial-card">
-              <blockquote>
-                “Share another perspective that highlights your strengths, leadership, or craft excellence.”
-              </blockquote>
-              <figcaption>
-                <span class="testimonial-card__name">Name Surname</span>
-                <span class="testimonial-card__role">Title · Company</span>
-              </figcaption>
-            </figure>
-          </div>
-        </div>
-      </section>
-
-      <section id="writing" class="section">
-        <div class="container">
-          <div class="section__header">
-            <p class="eyebrow">Writing</p>
-            <h2>Thinking out loud about product and design</h2>
-          </div>
-          <div class="grid grid--articles">
-            <article class="article-card">
-              <p class="article-card__meta">Month 00, 20XX</p>
-              <h3><a href="#">Article title placeholder that wraps to two lines</a></h3>
-              <p>
-                A short excerpt describing the article's takeaway or why it matters. Keep it punchy to encourage clicks.
-              </p>
-            </article>
-            <article class="article-card">
-              <p class="article-card__meta">Month 00, 20XX</p>
-              <h3><a href="#">Second article headline goes here</a></h3>
-              <p>
-                Use this to showcase thought leadership, share frameworks, or document learnings from recent projects.
-              </p>
-            </article>
-            <article class="article-card">
-              <p class="article-card__meta">Month 00, 20XX</p>
-              <h3><a href="#">Third article to feature</a></h3>
-              <p>
-                Link to blog posts, newsletters, or external publications. Provide just enough context to entice readers.
-              </p>
-            </article>
-          </div>
-          <div class="section__footer">
-            <a class="btn btn--ghost" href="#">View all writing</a>
-          </div>
-        </div>
-      </section>
-
       <section id="resume" class="section section--muted">
         <div class="container resume">
           <div class="section__header section__header--split">
@@ -278,22 +209,6 @@ s.
               </p>
               <a class="btn" href="#">Download resume</a>
             </div>
-          </div>
-        </div>
-      </section>
-
-      <section id="contact" class="section callout">
-        <div class="container callout__layout">
-          <div>
-            <p class="eyebrow">Contact</p>
-            <h2>Let's build the next thing together</h2>
-            <p>
-              Encourage visitors to reach out. Share your preferred channels and set expectations for response time or services.
-            </p>
-          </div>
-          <div>
-            <a class="btn btn--light" href="mailto:hello@example.com">hello@example.com</a>
-            <a class="btn btn--outline" href="#">Schedule a call</a>
           </div>
         </div>
       </section>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,0 +1,24 @@
+const navToggle = document.querySelector('.nav-toggle');
+const navList = document.querySelector('#primary-navigation');
+const yearEl = document.querySelector('#current-year');
+
+if (yearEl) {
+  yearEl.textContent = new Date().getFullYear();
+}
+
+if (navToggle && navList) {
+  const toggleMenu = () => {
+    const isOpen = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', String(!isOpen));
+    navList.dataset.open = String(!isOpen);
+  };
+
+  navToggle.addEventListener('click', toggleMenu);
+
+  navList.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      navToggle.setAttribute('aria-expanded', 'false');
+      navList.dataset.open = 'false';
+    });
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,518 @@
+:root {
+  --color-background: #f8f9fb;
+  --color-foreground: #ffffff;
+  --color-primary: #111827;
+  --color-secondary: #1f2937;
+  --color-muted: #e5e7eb;
+  --color-accent: #3b82f6;
+  --color-text: #111827;
+  --color-text-muted: #4b5563;
+  --color-border: rgba(17, 24, 39, 0.08);
+  --color-callout-bg: #111827;
+  --color-callout-text: #f9fafb;
+  --radius-base: 16px;
+  --radius-pill: 999px;
+  --shadow-soft: 0 20px 40px rgba(17, 24, 39, 0.08);
+  --shadow-hover: 0 24px 48px rgba(17, 24, 39, 0.12);
+  --container-width: min(1100px, 90vw);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--color-text);
+  background: var(--color-background);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-accent);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: var(--container-width);
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(248, 249, 251, 0.9);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 0;
+}
+
+.logo {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.site-nav ul {
+  list-style: none;
+  display: flex;
+  gap: 24px;
+  margin: 0;
+  padding: 0;
+  align-items: center;
+}
+
+.site-nav a {
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  transition: color 0.2s ease;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 20px;
+  border-radius: var(--radius-pill);
+  background: var(--color-primary);
+  color: white;
+  font-weight: 500;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.btn:hover,
+.btn:focus {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-hover);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.btn--ghost:hover,
+.btn--ghost:focus {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.btn--light {
+  background: var(--color-callout-text);
+  color: var(--color-callout-bg);
+}
+
+.btn--light:hover,
+.btn--light:focus {
+  color: var(--color-callout-bg);
+}
+
+.btn--outline {
+  background: transparent;
+  border-color: rgba(249, 250, 251, 0.4);
+  color: var(--color-callout-text);
+}
+
+.btn--outline:hover,
+.btn--outline:focus {
+  border-color: var(--color-callout-text);
+}
+
+.hero {
+  padding: 120px 0 80px;
+}
+
+.hero__layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 60px;
+  align-items: center;
+}
+
+.hero__content h1 {
+  font-size: clamp(2.5rem, 3vw + 1rem, 3.5rem);
+  line-height: 1.1;
+  margin-bottom: 24px;
+}
+
+.lead {
+  font-size: 1.1rem;
+  color: var(--color-text-muted);
+  margin-bottom: 28px;
+}
+
+.eyebrow {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  margin-bottom: 12px;
+}
+
+.hero__actions {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+
+.hero__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: var(--color-text-muted);
+}
+
+.hero__visual {
+  display: flex;
+  justify-content: center;
+}
+
+.portrait {
+  width: min(360px, 100%);
+  aspect-ratio: 3 / 4;
+  border-radius: 28px;
+  background: linear-gradient(160deg, #dbeafe, #f3f4f6 55%, #fff);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  position: relative;
+  overflow: hidden;
+  box-shadow: var(--shadow-soft);
+}
+
+.section {
+  padding: 96px 0;
+}
+
+.section--muted {
+  background: var(--color-foreground);
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.section__header {
+  max-width: 700px;
+  margin-bottom: 48px;
+}
+
+.section__header--split {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 48px;
+  align-items: start;
+}
+
+.section__footer {
+  margin-top: 48px;
+}
+
+.grid {
+  display: grid;
+  gap: 32px;
+}
+
+.grid--projects {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.project-card {
+  display: grid;
+  gap: 20px;
+  background: white;
+  border-radius: var(--radius-base);
+  padding: 28px;
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.project-card:hover,
+.project-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-hover);
+}
+
+.project-card__media {
+  background: var(--color-muted);
+  border-radius: var(--radius-base);
+  padding: 80px 20px;
+  text-align: center;
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+
+.project-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 0;
+  margin: 16px 0 0;
+  list-style: none;
+}
+
+.tag-list li {
+  padding: 6px 12px;
+  border-radius: var(--radius-pill);
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--color-accent);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.about__details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 32px;
+}
+
+.bullet-list {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--color-text-muted);
+}
+
+.testimonials .grid--testimonials {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.testimonial-card {
+  background: white;
+  border-radius: var(--radius-base);
+  padding: 32px;
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  display: grid;
+  gap: 20px;
+}
+
+.testimonial-card blockquote {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.5;
+}
+
+.testimonial-card__name {
+  font-weight: 600;
+  display: block;
+}
+
+.testimonial-card__role {
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.grid--articles {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.article-card {
+  background: white;
+  border-radius: var(--radius-base);
+  padding: 28px;
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  display: grid;
+  gap: 16px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.article-card:hover,
+.article-card:focus-within {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-hover);
+}
+
+.article-card__meta {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin-bottom: 8px;
+}
+
+.resume .btn {
+  margin-top: 16px;
+}
+
+.callout {
+  background: var(--color-callout-bg);
+  color: var(--color-callout-text);
+  border-radius: var(--radius-base);
+  margin: 0 var(--callout-horizontal-offset, 0);
+}
+
+.callout__layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 32px;
+  align-items: center;
+}
+
+.site-footer {
+  padding: 60px 0;
+}
+
+.footer__layout {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+
+.footer__links {
+  display: flex;
+  gap: 20px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.small-print {
+  color: var(--color-text-muted);
+  margin: 8px 0 0;
+}
+
+.placeholder {
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0.25), rgba(59, 130, 246, 0.05));
+  padding: 0 4px;
+  border-radius: 4px;
+}
+
+.visually-hidden {
+  position: absolute;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.nav-toggle {
+  display: none;
+  position: relative;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 1px solid var(--color-border);
+  background: white;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.nav-toggle__bar {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: var(--color-primary);
+  position: relative;
+}
+
+.nav-toggle__bar + .nav-toggle__bar {
+  margin-top: 4px;
+}
+
+@media (max-width: 900px) {
+  .site-header .container {
+    padding: 16px 0;
+  }
+
+  .hero {
+    padding-top: 80px;
+  }
+
+  .hero__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .hero__visual {
+    order: -1;
+  }
+
+  .section__header--split {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  .site-nav ul {
+    position: absolute;
+    top: 72px;
+    right: 24px;
+    left: 24px;
+    padding: 24px;
+    background: white;
+    border-radius: var(--radius-base);
+    border: 1px solid var(--color-border);
+    flex-direction: column;
+    gap: 16px;
+    box-shadow: var(--shadow-soft);
+    opacity: 0;
+    transform: translateY(-10px);
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  .site-nav ul[data-open='true'] {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .btn {
+    width: 100%;
+  }
+
+  .callout {
+    border-radius: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -242,6 +242,21 @@ img {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
+.work-group {
+  display: grid;
+  gap: 24px;
+  margin-top: 48px;
+}
+
+.work-group:first-of-type {
+  margin-top: 32px;
+}
+
+.work-group__title {
+  font-size: clamp(1.35rem, 1.2vw + 1rem, 1.8rem);
+  font-weight: 600;
+}
+
 .project-card {
   display: grid;
   gap: 20px;


### PR DESCRIPTION
## Summary
- add a static single-page portfolio layout with hero, work, about, testimonials, writing, resume, and contact sections
- apply modern styling inspired by andrewschmidt.net, including responsive grids, muted palette, and call-to-action buttons
- implement lightweight JavaScript for mobile navigation toggling and dynamic footer year
- document how to preview the static prototype locally via direct file open or a lightweight HTTP server

## Testing
- not run (static assets only)

------
https://chatgpt.com/codex/tasks/task_e_68e3635f77e88327bc3c21a865721cba